### PR TITLE
classification도메인을 TypeORM & PostgreSQL으로 마이그레이션

### DIFF
--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -3,6 +3,7 @@ import {
   ClassSerializerInterceptor,
   INestApplication,
   ValidationPipe,
+  VersioningType,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
@@ -17,6 +18,10 @@ export async function nestAppConfig<
   T extends INestApplication = INestApplication,
 >(app: T) {
   const reflector = app.get<Reflector>(Reflector);
+
+  app.enableVersioning({
+    type: VersioningType.URI,
+  });
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/common/dto/pagination.dto.ts
+++ b/src/common/dto/pagination.dto.ts
@@ -38,6 +38,10 @@ export class PaginationQuery {
   @IsOptional()
   @IsEnum(OrderType)
   readonly order: OrderType;
+
+  getOffset(): number {
+    return Math.max(0, (this.page - 1) * this.limit);
+  }
 }
 
 // Pagination API Response의 Metadata로 추가해주세용

--- a/src/infrastructure/database/entities/ai-classification.entity.ts
+++ b/src/infrastructure/database/entities/ai-classification.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, JoinColumn, ManyToOne, Relation } from 'typeorm';
+import {
+  Column,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  Relation,
+} from 'typeorm';
 import { BaseEntity } from './base.entity';
 import { Folder } from './folder.entity';
 
@@ -19,7 +26,7 @@ export class AIClassification extends BaseEntity {
   @Column({ name: 'completed_at', nullable: true })
   completedAt: Date;
 
-  @Column({ name: 'deleted_at', nullable: true })
+  @DeleteDateColumn({ name: 'deleted_at', nullable: true })
   deletedAt: Date;
 
   @ManyToOne(() => Folder)

--- a/src/modules/classification/classification.module.ts
+++ b/src/modules/classification/classification.module.ts
@@ -8,11 +8,16 @@ import {
   Post,
   PostSchema,
 } from '@src/infrastructure/database/schema';
+import { FoldersPGRepository } from '../folders/folders.pg.repository';
 import { FolderRepository } from '../folders/folders.repository';
+import { PostsPGRepository } from '../posts/posts.pg.repository';
 import { PostsRepository } from '../posts/posts.repository';
 import { ClassificationController } from './classification.controller';
+import { ClassificationPGRepository } from './classification.pg.repository';
 import { ClassficiationRepository } from './classification.repository';
 import { ClassificationService } from './classification.service';
+import { ClassificationV2Controller } from './classification.v2.controller';
+import { ClassificationV2Service } from './classification.v2.service';
 
 @Module({
   imports: [
@@ -22,12 +27,16 @@ import { ClassificationService } from './classification.service';
       { name: Post.name, schema: PostSchema },
     ]),
   ],
-  controllers: [ClassificationController],
+  controllers: [ClassificationController, ClassificationV2Controller],
   providers: [
     ClassificationService,
+    ClassificationV2Service,
     ClassficiationRepository,
+    ClassificationPGRepository,
     PostsRepository,
+    PostsPGRepository,
     FolderRepository,
+    FoldersPGRepository,
   ],
   exports: [ClassificationService],
 })

--- a/src/modules/classification/classification.pg.repository.ts
+++ b/src/modules/classification/classification.pg.repository.ts
@@ -5,7 +5,7 @@ import { FolderType } from '@src/infrastructure/database/types/folder-type.enum'
 import { ClassificationFolderWithCount } from './dto/classification.dto';
 
 @Injectable()
-export class ClassficiationRepository extends Repository<AIClassification> {
+export class ClassificationPGRepository extends Repository<AIClassification> {
   constructor(private dataSource: DataSource) {
     super(AIClassification, dataSource.createEntityManager());
   }
@@ -73,27 +73,28 @@ export class ClassficiationRepository extends Repository<AIClassification> {
   async findContainedFolderByUserId(
     userId: string,
   ): Promise<ClassificationFolderWithCount[]> {
-    const result = await this.createQueryBuilder('classification')
-      .select([
-        'folder.id as folderId',
-        'folder.name as folderName',
-        'COUNT(classification.id) as postCount',
-        'CASE WHEN folder.visible = true THEN false ELSE true END as isAIGenerated',
-      ])
-      .leftJoin(
-        'folders',
-        'folder',
-        'folder.id = classification.suggestedFolderId',
-      )
-      .where('classification.deletedAt IS NULL')
-      .andWhere('folder.userId = :userId', { userId })
-      .andWhere('folder.type != :type', { type: FolderType.DEFAULT })
-      .groupBy('folder.id')
-      .addGroupBy('folder.name')
-      .addGroupBy('folder.visible')
-      .orderBy('postCount', 'DESC')
-      .addOrderBy('folder.createdAt', 'DESC')
-      .getRawMany();
+    const result: ClassificationFolderWithCount[] =
+      await this.createQueryBuilder('classification')
+        .select([
+          'folder.id as "folderId"',
+          'folder.name as "folderName"',
+          'COUNT(classification.id) as "postCount"',
+          'CASE WHEN folder.visible = true THEN false ELSE true END as "isAIGenerated"',
+        ])
+        .leftJoin(
+          'folders',
+          'folder',
+          'folder.id = classification.suggestedFolderId',
+        )
+        .where('classification.deletedAt IS NULL')
+        .andWhere('folder.userId = :userId', { userId })
+        .andWhere('folder.type != :type', { type: FolderType.DEFAULT })
+        .groupBy('folder.id')
+        .addGroupBy('folder.name')
+        .addGroupBy('folder.visible')
+        .orderBy('"postCount"', 'DESC')
+        .addOrderBy('folder.createdAt', 'DESC')
+        .getRawMany();
 
     return result;
   }

--- a/src/modules/classification/classification.pg.repository.ts
+++ b/src/modules/classification/classification.pg.repository.ts
@@ -110,14 +110,10 @@ export class ClassificationPGRepository extends Repository<AIClassification> {
   }
 
   async deleteManyBySuggestedFolderIdList(
-    suggestedFolderId: string[] | string,
+    suggestedFolderIdList: string[],
   ): Promise<boolean> {
-    const ids = Array.isArray(suggestedFolderId)
-      ? suggestedFolderId
-      : [suggestedFolderId];
-
     await this.update(
-      { suggestedFolderId: In(ids) },
+      { suggestedFolderId: In(suggestedFolderIdList) },
       { deletedAt: new Date() },
     );
 

--- a/src/modules/classification/classification.pg.repository.ts
+++ b/src/modules/classification/classification.pg.repository.ts
@@ -84,11 +84,10 @@ export class ClassificationPGRepository extends Repository<AIClassification> {
         .innerJoin(
           'folders',
           'folder',
-          'folder.id = classification.suggestedFolderId',
+          'folder.id = classification.suggestedFolderId AND folder.userId = :userId AND folder.type != :type',
+          { userId, type: FolderType.DEFAULT },
         )
         .where('classification.deletedAt IS NULL')
-        .andWhere('folder.userId = :userId', { userId })
-        .andWhere('folder.type != :type', { type: FolderType.DEFAULT })
         .groupBy('folder.id')
         .addGroupBy('folder.name')
         .addGroupBy('folder.visible')

--- a/src/modules/classification/classification.pg.repository.ts
+++ b/src/modules/classification/classification.pg.repository.ts
@@ -81,7 +81,7 @@ export class ClassificationPGRepository extends Repository<AIClassification> {
           'COUNT(classification.id) as "postCount"',
           'CASE WHEN folder.visible = true THEN false ELSE true END as "isAIGenerated"',
         ])
-        .leftJoin(
+        .innerJoin(
           'folders',
           'folder',
           'folder.id = classification.suggestedFolderId',

--- a/src/modules/classification/classification.v2.controller.ts
+++ b/src/modules/classification/classification.v2.controller.ts
@@ -1,0 +1,135 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { GetUser, PaginationMetadata, PaginationQuery } from '@src/common';
+import { JwtGuard } from '../users/guards';
+import { ClassificationV2Service } from './classification.v2.service';
+import {
+  ClassificationControllerDocs,
+  DeleteAIClassificationDocs,
+  GetAIFolderNameListDocs,
+  GetAIPostListDocs,
+  PatchAIPostDocs,
+  PatchAIPostListDocs,
+} from './docs';
+import { CountClassificationDocs } from './docs/countClassification.docs';
+import { UpdateAIClassificationDto } from './dto/classification.dto';
+import { AIFolderNameListResponse } from './response/ai-folder-list.dto';
+import { AIPostListResponse } from './response/ai-post-list.dto';
+
+@Controller('v2/classification')
+@UseGuards(JwtGuard)
+@ClassificationControllerDocs
+export class ClassificationV2Controller {
+  constructor(
+    private readonly classificationService: ClassificationV2Service,
+  ) {}
+
+  @Get('/count')
+  @CountClassificationDocs
+  @HttpCode(HttpStatus.OK)
+  async countClassifiedPost(@GetUser() userId: string): Promise<number> {
+    return await this.classificationService.countClassifiedPost(userId);
+  }
+
+  @Get('/folders')
+  @GetAIFolderNameListDocs
+  @HttpCode(HttpStatus.OK)
+  async getSuggestedFolderNameList(
+    @GetUser() userId: string,
+  ): Promise<AIFolderNameListResponse> {
+    const folders = await this.classificationService.getFolderNameList(userId);
+    return new AIFolderNameListResponse(folders);
+  }
+
+  @Get('/posts')
+  @GetAIPostListDocs
+  @HttpCode(HttpStatus.OK)
+  async getSuggestedPostList(
+    @GetUser() userId: string,
+    @Query() pagingQuery: PaginationQuery,
+  ): Promise<AIPostListResponse> {
+    const { count, classificationPostList } =
+      await this.classificationService.getPostList(userId, pagingQuery);
+
+    const metadata = new PaginationMetadata(
+      pagingQuery.page,
+      pagingQuery.limit,
+      count,
+    );
+
+    return new AIPostListResponse(metadata, classificationPostList);
+  }
+
+  @Get('/posts/:folderId')
+  @GetAIPostListDocs
+  @HttpCode(HttpStatus.OK)
+  async getSuggestedPostListInFolder(
+    @GetUser() userId: string,
+    @Param('folderId') folderId: string,
+    @Query() pagingQuery: PaginationQuery,
+  ): Promise<AIPostListResponse> {
+    const { count, classificationPostList } =
+      await this.classificationService.getPostListInFolder(
+        userId,
+        folderId,
+        pagingQuery,
+      );
+
+    const metadata = new PaginationMetadata(
+      pagingQuery.page,
+      pagingQuery.limit,
+      count,
+    );
+
+    return new AIPostListResponse(metadata, classificationPostList);
+  }
+
+  @Patch('/posts')
+  @PatchAIPostListDocs
+  @HttpCode(HttpStatus.OK)
+  async moveAllPost(
+    @GetUser() userId: string,
+    @Query('suggestionFolderId') suggestionFolderId: string,
+  ): Promise<{ success: boolean }> {
+    const result =
+      await this.classificationService.moveAllPostTosuggestionFolderV2(
+        userId,
+        suggestionFolderId,
+      );
+
+    return { success: result };
+  }
+
+  @Patch('/posts/:postId')
+  @PatchAIPostDocs
+  async moveOnePost(
+    @GetUser() userId: string,
+    @Param('postId') postId: string,
+    @Body() dto: UpdateAIClassificationDto,
+  ): Promise<void> {
+    await this.classificationService.moveOnePostTosuggestionFolder(
+      userId,
+      postId,
+      dto.suggestionFolderId,
+    );
+  }
+
+  @Delete('/posts/:postId')
+  @DeleteAIClassificationDocs
+  async abortClassification(
+    @GetUser() userId: string,
+    @Param('postId') postId: string,
+  ): Promise<void> {
+    await this.classificationService.abortClassification(userId, postId);
+  }
+}

--- a/src/modules/classification/classification.v2.controller.ts
+++ b/src/modules/classification/classification.v2.controller.ts
@@ -26,7 +26,7 @@ import { UpdateAIClassificationDto } from './dto/classification.dto';
 import { AIFolderNameListResponse } from './response/ai-folder-list.dto';
 import { AIPostListResponse } from './response/ai-post-list.dto';
 
-@Controller('v2/classification')
+@Controller({ version: '2', path: 'classification' })
 @UseGuards(JwtGuard)
 @ClassificationControllerDocs
 export class ClassificationV2Controller {

--- a/src/modules/classification/classification.v2.controller.ts
+++ b/src/modules/classification/classification.v2.controller.ts
@@ -72,7 +72,6 @@ export class ClassificationV2Controller {
 
   @Get('/posts/:folderId')
   @GetAIPostListDocs
-  @HttpCode(HttpStatus.OK)
   async getSuggestedPostListInFolder(
     @GetUser() userId: string,
     @Param('folderId') folderId: string,
@@ -98,11 +97,11 @@ export class ClassificationV2Controller {
   @PatchAIPostListDocs
   async moveAllPost(
     @GetUser() userId: string,
-    @Query('suggestionFolderId') suggestionFolderId: string,
+    @Body() dto: UpdateAIClassificationDto,
   ) {
     return await this.classificationService.moveAllPostTosuggestionFolder(
       userId,
-      suggestionFolderId,
+      dto.suggestionFolderId,
     );
   }
 

--- a/src/modules/classification/classification.v2.controller.ts
+++ b/src/modules/classification/classification.v2.controller.ts
@@ -96,18 +96,14 @@ export class ClassificationV2Controller {
 
   @Patch('/posts')
   @PatchAIPostListDocs
-  @HttpCode(HttpStatus.OK)
   async moveAllPost(
     @GetUser() userId: string,
     @Query('suggestionFolderId') suggestionFolderId: string,
-  ): Promise<{ success: boolean }> {
-    const result =
-      await this.classificationService.moveAllPostTosuggestionFolderV2(
-        userId,
-        suggestionFolderId,
-      );
-
-    return { success: result };
+  ) {
+    return await this.classificationService.moveAllPostTosuggestionFolder(
+      userId,
+      suggestionFolderId,
+    );
   }
 
   @Patch('/posts/:postId')
@@ -116,7 +112,7 @@ export class ClassificationV2Controller {
     @GetUser() userId: string,
     @Param('postId') postId: string,
     @Body() dto: UpdateAIClassificationDto,
-  ): Promise<void> {
+  ) {
     await this.classificationService.moveOnePostTosuggestionFolder(
       userId,
       postId,

--- a/src/modules/classification/classification.v2.service.ts
+++ b/src/modules/classification/classification.v2.service.ts
@@ -1,0 +1,191 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { PaginationQuery, sum } from '@src/common';
+import { FoldersPGRepository } from '../folders/folders.pg.repository';
+import { PostsPGRepository } from '../posts/posts.pg.repository';
+import { ClassificationPGRepository } from './classification.pg.repository';
+import { ClassificationFolderWithCount } from './dto/classification.dto';
+import { C001 } from './error';
+
+@Injectable()
+export class ClassificationV2Service {
+  constructor(
+    private readonly classificationRepository: ClassificationPGRepository,
+    private readonly postRepository: PostsPGRepository,
+    private readonly folderRepository: FoldersPGRepository,
+  ) {}
+
+  async countClassifiedPost(userId: string): Promise<number> {
+    return await this.classificationRepository.countClassifiedPostByUserId(
+      userId,
+    );
+  }
+
+  async getFolderNameList(
+    userId: string,
+  ): Promise<ClassificationFolderWithCount[]> {
+    return await this.classificationRepository.findContainedFolderByUserId(
+      userId,
+    );
+  }
+
+  async getPostList(userId: string, pagingQuery: PaginationQuery) {
+    const { count, orderedFolderIdList } =
+      await this.getFolderCountAndOrder(userId);
+
+    if (orderedFolderIdList.length === 0) {
+      return { count: 0, classificationPostList: [] };
+    }
+    const offset = (pagingQuery.page - 1) * pagingQuery.limit;
+    const classificationPostList =
+      await this.postRepository.findAndSortBySuggestedFolderIds(
+        userId,
+        orderedFolderIdList,
+        offset,
+        pagingQuery.limit,
+      );
+
+    return { count, classificationPostList };
+  }
+
+  async getFolderCountAndOrder(userId: string) {
+    const orderedFolderList =
+      await this.classificationRepository.findContainedFolderByUserId(userId);
+
+    const count = sum(orderedFolderList, (folder) => Number(folder.postCount));
+    const orderedFolderIdList = orderedFolderList.map(
+      (folder) => folder.folderId,
+    );
+
+    return { count, orderedFolderIdList };
+  }
+
+  async getPostListInFolder(
+    userId: string,
+    folderId: string,
+    pagingQuery: PaginationQuery,
+  ) {
+    const offset = (pagingQuery.page - 1) * pagingQuery.limit;
+
+    const [count, classificationPostList] = await Promise.all([
+      this.classificationRepository.getClassificationPostCount(
+        userId,
+        folderId,
+      ),
+      this.postRepository.findBySuggestedFolderId(
+        userId,
+        folderId,
+        offset,
+        pagingQuery.limit,
+      ),
+    ]);
+
+    return { count, classificationPostList };
+  }
+
+  async moveAllPostTosuggestionFolder(
+    userId: string,
+    suggestedFolderId: string,
+  ): Promise<void> {
+    const postIdList = (
+      await this.postRepository.findFolderIdsBySuggestedFolderId(
+        userId,
+        suggestedFolderId,
+      )
+    ).map((post) => post.id);
+
+    if (postIdList.length > 0) {
+      await this.postRepository.updatePostListFolder(
+        userId,
+        postIdList,
+        suggestedFolderId,
+      );
+    }
+
+    await this.classificationRepository.deleteManyBySuggestedFolderIdList(
+      suggestedFolderId,
+    );
+  }
+
+  async moveAllPostTosuggestionFolderV2(
+    userId: string,
+    suggestedFolderId: string,
+  ): Promise<boolean> {
+    await this.folderRepository.makeFolderVisible(suggestedFolderId);
+
+    const targetClassificationIds =
+      await this.classificationRepository.getClassificationBySuggestedFolderId(
+        suggestedFolderId,
+      );
+
+    const targetPostIds =
+      await this.postRepository.findPostsBySuggestedFolderIds(
+        userId,
+        targetClassificationIds,
+      );
+
+    if (targetPostIds.length > 0) {
+      await this.postRepository.updatePostListFolder(
+        userId,
+        targetPostIds,
+        suggestedFolderId,
+      );
+    }
+
+    await this.classificationRepository.deleteManyBySuggestedFolderIdList(
+      suggestedFolderId,
+    );
+
+    return true;
+  }
+
+  async moveOnePostTosuggestionFolder(
+    userId: string,
+    postId: string,
+    suggestedFolderId: string,
+  ): Promise<void> {
+    await this.folderRepository.makeFolderVisible(suggestedFolderId);
+
+    const post = await this.postRepository.findOne({
+      where: { id: postId, userId },
+    });
+
+    await this.postRepository.findAndupdateFolderId(
+      userId,
+      postId,
+      suggestedFolderId,
+    );
+
+    if (post.aiClassificationId) {
+      await this.classificationRepository.softDelete(post.aiClassificationId);
+    }
+  }
+
+  async abortClassification(userId: string, postId: string): Promise<boolean> {
+    const post = await this.postRepository.findPostOrThrow({
+      id: postId,
+    });
+
+    if (!post.aiClassificationId) {
+      throw new BadRequestException(C001);
+    }
+
+    const classification = await this.classificationRepository.findById(
+      post.aiClassificationId,
+    );
+
+    if (!classification) {
+      throw new BadRequestException(C001);
+    }
+
+    await this.classificationRepository.softDelete(classification.id);
+    return true;
+  }
+
+  async deleteClassificationBySuggestedFolderId(
+    suggestedFolderId: string[] | string,
+  ): Promise<boolean> {
+    return await this.classificationRepository.deleteManyBySuggestedFolderIdList(
+      suggestedFolderId,
+    );
+  }
+}

--- a/src/modules/classification/classification.v2.service.ts
+++ b/src/modules/classification/classification.v2.service.ts
@@ -35,7 +35,7 @@ export class ClassificationV2Service {
     if (orderedFolderIdList.length === 0) {
       return { count: 0, classificationPostList: [] };
     }
-    const offset = (pagingQuery.page - 1) * pagingQuery.limit;
+    const offset = pagingQuery.getOffset();
     const classificationPostList =
       await this.postRepository.findAndSortBySuggestedFolderIds(
         userId,
@@ -64,7 +64,7 @@ export class ClassificationV2Service {
     folderId: string,
     pagingQuery: PaginationQuery,
   ) {
-    const offset = (pagingQuery.page - 1) * pagingQuery.limit;
+    const offset = pagingQuery.getOffset();
 
     const [count, classificationPostList] = await Promise.all([
       this.classificationRepository.getClassificationPostCount(

--- a/src/modules/classification/classification.v2.service.ts
+++ b/src/modules/classification/classification.v2.service.ts
@@ -85,30 +85,6 @@ export class ClassificationV2Service {
   async moveAllPostTosuggestionFolder(
     userId: string,
     suggestedFolderId: string,
-  ): Promise<void> {
-    const postIdList = (
-      await this.postRepository.findFolderIdsBySuggestedFolderId(
-        userId,
-        suggestedFolderId,
-      )
-    ).map((post) => post.id);
-
-    if (postIdList.length > 0) {
-      await this.postRepository.updatePostListFolder(
-        userId,
-        postIdList,
-        suggestedFolderId,
-      );
-    }
-
-    await this.classificationRepository.deleteManyBySuggestedFolderIdList(
-      suggestedFolderId,
-    );
-  }
-
-  async moveAllPostTosuggestionFolderV2(
-    userId: string,
-    suggestedFolderId: string,
   ): Promise<boolean> {
     await this.folderRepository.makeFolderVisible(suggestedFolderId);
 

--- a/src/modules/classification/classification.v2.service.ts
+++ b/src/modules/classification/classification.v2.service.ts
@@ -107,9 +107,9 @@ export class ClassificationV2Service {
       );
     }
 
-    await this.classificationRepository.deleteManyBySuggestedFolderIdList(
+    await this.classificationRepository.deleteManyBySuggestedFolderIdList([
       suggestedFolderId,
-    );
+    ]);
 
     return true;
   }
@@ -158,10 +158,10 @@ export class ClassificationV2Service {
   }
 
   async deleteClassificationBySuggestedFolderId(
-    suggestedFolderId: string[] | string,
+    suggestedFolderIdList: string[],
   ): Promise<boolean> {
     return await this.classificationRepository.deleteManyBySuggestedFolderIdList(
-      suggestedFolderId,
+      suggestedFolderIdList,
     );
   }
 }

--- a/src/modules/classification/docs/countClassification.docs.ts
+++ b/src/modules/classification/docs/countClassification.docs.ts
@@ -1,9 +1,14 @@
 import { applyDecorators } from '@nestjs/common';
-import { ApiOperation } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
 
 export const CountClassificationDocs = applyDecorators(
   ApiOperation({
     summary: 'AI 분류된 개수를 반환합니다',
     description: '반환 데이터 타입은 정수입니다!',
+  }),
+  ApiResponse({
+    status: 200,
+    description: '분류된 Post의 개수',
+    type: Number,
   }),
 );

--- a/src/modules/classification/docs/deleteAIClassification.docs.ts
+++ b/src/modules/classification/docs/deleteAIClassification.docs.ts
@@ -1,6 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { AIFolderNameListResponse } from '../response/ai-folder-list.dto';
 
 export const DeleteAIClassificationDocs = applyDecorators(
   ApiOperation({

--- a/src/modules/classification/docs/patchAIPost.docs.ts
+++ b/src/modules/classification/docs/patchAIPost.docs.ts
@@ -4,7 +4,7 @@ import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
 export const PatchAIPostDocs = applyDecorators(
   ApiOperation({
     summary: 'Post 하나 이동',
-    description: '추천해준 폴더로 post이동',
+    description: '추천해준 폴더로 post이동. postId가 필요합니다.',
   }),
   ApiResponse({}),
   ApiBearerAuth(),

--- a/src/modules/classification/docs/patchAIPost.docs.ts
+++ b/src/modules/classification/docs/patchAIPost.docs.ts
@@ -1,14 +1,11 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { AIPostListResponse } from '../response/ai-post-list.dto';
 
 export const PatchAIPostDocs = applyDecorators(
   ApiOperation({
     summary: 'Post 하나 이동',
     description: '추천해준 폴더로 post이동',
   }),
-  ApiResponse({
-    type: AIPostListResponse,
-  }),
+  ApiResponse({}),
   ApiBearerAuth(),
 );

--- a/src/modules/classification/docs/patchAIPostList.docs.ts
+++ b/src/modules/classification/docs/patchAIPostList.docs.ts
@@ -1,6 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { AIPostListResponse } from '../response/ai-post-list.dto';
 
 export const PatchAIPostListDocs = applyDecorators(
   ApiOperation({
@@ -8,7 +7,7 @@ export const PatchAIPostListDocs = applyDecorators(
     description: '추천 폴더 안에 들어있는 Post(링크)를 추천 폴더로 전부 이동',
   }),
   ApiResponse({
-    type: AIPostListResponse,
+    type: Boolean,
   }),
   ApiBearerAuth(),
 );

--- a/src/modules/classification/dto/classification.dto.ts
+++ b/src/modules/classification/dto/classification.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsMongoId, IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { PostAiStatus } from '@src/modules/posts/posts.constant';
 
 export interface ClassificationFolderWithCount {
@@ -51,7 +51,7 @@ export class ClassificationPostList {
 
 export class UpdateAIClassificationDto {
   @IsNotEmpty()
-  @IsMongoId()
+  @IsString()
   @ApiProperty({ description: '추천된 폴더의 아이디' })
   suggestionFolderId: string;
 }

--- a/src/modules/posts/posts.module.ts
+++ b/src/modules/posts/posts.module.ts
@@ -20,6 +20,7 @@ import { AiClassificationModule } from '../ai-classification/ai-classification.m
 import { FolderRepository } from '../folders/folders.repository';
 import { PostKeywordsRepository } from './postKeywords.repository';
 import { PostsController } from './posts.controller';
+import { PostsPGRepository } from './posts.pg.repository';
 import { PostsService } from './posts.service';
 
 @Module({
@@ -41,7 +42,8 @@ import { PostsService } from './posts.service';
     FolderRepository,
     AwsLambdaService,
     PostKeywordsRepository,
+    PostsPGRepository,
   ],
-  exports: [PostsService, PostsRepository],
+  exports: [PostsService, PostsRepository, PostsPGRepository],
 })
 export class PostsModule {}

--- a/src/modules/posts/posts.pg.repository.ts
+++ b/src/modules/posts/posts.pg.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { FilterQuery, Types } from 'mongoose';
+import { FilterQuery } from 'mongoose';
 import { DataSource, FindOptionsWhere, IsNull, Not, Repository } from 'typeorm';
 import { OrderType } from '@src/common';
 import { Post } from '@src/infrastructure/database/entities/post.entity';
@@ -149,7 +149,7 @@ export class PostsPGRepository extends Repository<Post> {
 
   async findBySuggestedFolderId(
     userId: string,
-    suggestedFolderId: Types.ObjectId,
+    suggestedFolderId: string,
     offset: number,
     limit: number,
   ): Promise<ClassificationPostList[]> {
@@ -234,44 +234,58 @@ export class PostsPGRepository extends Repository<Post> {
 
     return count;
   }
-
   async findAndSortBySuggestedFolderIds(
-    userId: Types.ObjectId,
-    suggestedFolderIds: Types.ObjectId[],
+    userId: string,
+    suggestedFolderIds: string[],
     offset: number,
     limit: number,
   ): Promise<ClassificationPostList[]> {
-    return await this.createQueryBuilder('post')
-      .leftJoinAndSelect('post.aiClassification', 'aiClassification')
-      .where('post.userId = :userId', { userId })
-      .andWhere('aiClassification.deletedAt IS NULL')
-      .andWhere(
-        'aiClassification.suggestedFolderId IN (:...suggestedFolderIds)',
-        {
-          suggestedFolderIds,
-        },
-      )
-      .addSelect(
-        `ARRAY_POSITION(:suggestedFolderIds::uuid[], aiClassification.suggestedFolderId::text)`,
-        'order',
-      )
-      .orderBy('order', 'ASC')
-      .addOrderBy('post.createdAt', 'DESC')
-      .skip(offset)
-      .take(limit)
+    const arraySql = suggestedFolderIds.map((id) => `'${id}'`).join(', '); // 문자열 uuid 배열
+
+    const result = await this.dataSource
+      .createQueryBuilder()
       .select([
-        'aiClassification.suggestedFolderId as folderId',
-        'post.id as postId',
-        'post.title as title',
-        'post.url as url',
-        'post.description as description',
-        'post.createdAt as createdAt',
-        'post.readAt as readAt',
-        'post.aiStatus as aiStatus',
-        'post.thumbnailImgUrl as thumbnailImgUrl',
-        'aiClassification.keywords as keywords',
+        'post.id AS "postId"',
+        'post.title AS "title"',
+        'post.url AS "url"',
+        'post.description AS "description"',
+        'post.created_at AS "createdAt"',
+        'post.read_at AS "readAt"',
+        'post.ai_status AS "aiStatus"',
+        'post.thumbnail_img_url AS "thumbnailImgUrl"',
+        'ai.keywords AS "keywords"',
+        'ai.suggested_folder_id AS "folderId"',
+        `array_position(ARRAY[${arraySql}]::uuid[], ai.suggested_folder_id) AS "folder_order"`,
       ])
-      .getRawMany<ClassificationPostList>();
+      .from('posts', 'post')
+      .innerJoin(
+        'ai_classifications',
+        'ai',
+        'post.ai_classification_id = ai.id',
+      )
+      .where('post.user_id = :userId', { userId })
+      .andWhere('ai.deleted_at IS NULL')
+      .andWhere('ai.suggested_folder_id IN (:...suggestedFolderIds)', {
+        suggestedFolderIds,
+      })
+      .orderBy('folder_order', 'ASC')
+      .addOrderBy('post.created_at', 'DESC')
+      .offset(offset)
+      .limit(limit)
+      .getRawMany();
+
+    return result.map((row) => ({
+      postId: row.postId,
+      folderId: row.folderId,
+      title: row.title,
+      url: row.url,
+      description: row.description,
+      createdAt: row.createdAt,
+      readAt: row.readAt,
+      aiStatus: row.aiStatus,
+      thumbnailImgUrl: row.thumbnailImgUrl,
+      keywords: row.keywords,
+    }));
   }
 
   async findFolderIdsBySuggestedFolderId(


### PR DESCRIPTION
## PR 내용
classification 도메인을 TypeORM & PostgreSQL 기반으로 마이그레이션했습니다.

## 추가 및 변경 사항
- classification 관련 서비스/리포지토리를 TypeORM + PostgreSQL 기반으로 마이그레이션했습니다.
- 엔드포인트 충돌을 방지하기 위해 `@Controller('v2/classification')` 으로 v2 prefix를 추가했습니다.

## Comment
테스트코드는 다음 pr에 올릴께욤 
더미데이터 넣어서 테스트 했는데 sql [노션](https://www.notion.so/pg-1bfbee7f599680d39447e9008aa61071)에 올려뒀어욤

## 스크린샷
<details>
<summary>스크린샷 </summary>

![image](https://github.com/user-attachments/assets/2142dc53-e7b4-4ad1-aed3-14019f49aeba)
![image](https://github.com/user-attachments/assets/dc663947-686c-44f0-a0c6-c2a0fa3b329a)
![image](https://github.com/user-attachments/assets/3e367f80-46d5-4d26-9584-b3ddab9200db)
![image](https://github.com/user-attachments/assets/2dd5b1cf-fac9-41e0-a5c7-1df9d6c349ef)
![image](https://github.com/user-attachments/assets/13ed6453-68fe-4c88-baf5-f63197bc0798)
</details>
